### PR TITLE
Handle empty directory search response

### DIFF
--- a/lib/ueberauth/strategy/nusso/api.ex
+++ b/lib/ueberauth/strategy/nusso/api.ex
@@ -92,6 +92,10 @@ defmodule Ueberauth.Strategy.NuSSO.API do
     end
   end
 
+  defp handle_response({:ok, %HTTPoison.Response{status_code: 200, body: ""}}) do
+    {:ok, %{results: []}}
+  end
+
   defp handle_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
     {:ok, Jason.decode!(body) |> atomify()}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UeberauthOpenam.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @url "https://github.com/nulib/ueberauth_nusso"
 
   def project do

--- a/test/support/mock_endpoint.ex
+++ b/test/support/mock_endpoint.ex
@@ -51,9 +51,13 @@ defmodule Ueberauth.NuSSO.MockEndpoint do
      }}
   end
 
+  defp directory_search_response("empty-directory-sso-token"),
+    do: {:ok, %HTTPoison.Response{status_code: 200, body: ""}}
+
   defp validate_response("test-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("bad-directory-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("bad-sso-token"), do: http_response(407, %{redirecturl: @redirecturl})
+  defp validate_response("empty-directory-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("error-sso-token"), do: http_response(500, "Server Error")
 
   defp send_headers(headers) do

--- a/test/ueberauth/strategy/nusso/api_test.exs
+++ b/test/ueberauth/strategy/nusso/api_test.exs
@@ -67,6 +67,17 @@ defmodule Ueberauth.Strategy.NuSSO.APITest do
       assert_received({:header, {"webssotoken", "bad-directory-sso-token"}})
     end
 
+    test "token validation with attributes when token is valid but attributes empty" do
+      assert {:ok, user} = API.redeem_token("empty-directory-sso-token")
+      assert user.uid == "abc123"
+      assert user.displayName == "abc123"
+      assert user.mail == "abc123@e.northwestern.edu"
+      refute user |> Map.has_key?(:eduPersonNickname)
+
+      assert_received({:header, {"apikey", "test-consumer-key"}})
+      assert_received({:header, {"webssotoken", "empty-directory-sso-token"}})
+    end
+
     test "bad token" do
       assert {:error, response} = API.redeem_token("bad-sso-token")
       assert response.message == "Missing, invalid, or expired SSO Token"


### PR DESCRIPTION
## Description

The Agentless SSO API sometimes returns an empty body on calls to `validate-with-directory-search-response`, and this is preventing valid users from logging in. See https://github.com/nulib/repodev_planning_and_docs/issues/702

## Solution

Update API to handle empty responses.