### PR TITLE
Fail gracefully when NUSSO returns invalid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Northwestern University Agentless SSO strategy for [Ueberauth](https://github.co
 def deps do
   [
     {:ueberauth, "~> 0.2"},
-    {:ueberauth_nusso, "~> 0.1.0"},
+    {:ueberauth_nusso, "~> 0.3"},
   ]
 end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,17 @@
 defmodule UeberauthOpenam.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.3.0"
   @url "https://github.com/nulib/ueberauth_nusso"
 
   def project do
     [
       app: :ueberauth_nusso,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.9",
       name: "Ueberauth NuSSO strategy",
       description: "Ueberauth strategy for use with Northwestern University Agentless SSO",
+      xref: [exclude: [Jason]],
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/support/mock_endpoint.ex
+++ b/test/support/mock_endpoint.ex
@@ -5,6 +5,12 @@ defmodule Ueberauth.NuSSO.MockEndpoint do
 
   @behaviour HTTPoison.Base
   @base_url "https://test.example.edu/agentless-websso"
+  @non_json_response """
+  <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+  <html>
+    <body>This is not a JSON response</body>
+  </html>
+  """
   @redirecturl "https://test-nusso.example.edu/nusso/XUI/?#login&realm=test&authIndexType=service&service=ldap-registry&goto=https://example.edu/"
 
   def get("#{@base_url}/get-ldap-redirect-url", headers) do
@@ -54,10 +60,14 @@ defmodule Ueberauth.NuSSO.MockEndpoint do
   defp directory_search_response("empty-directory-sso-token"),
     do: {:ok, %HTTPoison.Response{status_code: 200, body: ""}}
 
+  defp directory_search_response("non-json-sso-token"),
+    do: {:ok, %HTTPoison.Response{status_code: 200, body: @non_json_response}}
+
   defp validate_response("test-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("bad-directory-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("bad-sso-token"), do: http_response(407, %{redirecturl: @redirecturl})
   defp validate_response("empty-directory-sso-token"), do: http_response(%{netid: "abc123"})
+  defp validate_response("non-json-sso-token"), do: http_response(%{netid: "abc123"})
   defp validate_response("error-sso-token"), do: http_response(500, "Server Error")
 
   defp send_headers(headers) do

--- a/test/ueberauth/strategy/nusso/api_test.exs
+++ b/test/ueberauth/strategy/nusso/api_test.exs
@@ -78,6 +78,17 @@ defmodule Ueberauth.Strategy.NuSSO.APITest do
       assert_received({:header, {"webssotoken", "empty-directory-sso-token"}})
     end
 
+    test "token validation when directory_search_response/1 returns a bad response" do
+      assert {:ok, user} = API.redeem_token("non-json-sso-token")
+      assert user.uid == "abc123"
+      assert user.displayName == "abc123"
+      assert user.mail == "abc123@e.northwestern.edu"
+      refute user |> Map.has_key?(:eduPersonNickname)
+
+      assert_received({:header, {"apikey", "test-consumer-key"}})
+      assert_received({:header, {"webssotoken", "non-json-sso-token"}})
+    end
+
     test "bad token" do
       assert {:error, response} = API.redeem_token("bad-sso-token")
       assert response.message == "Missing, invalid, or expired SSO Token"


### PR DESCRIPTION
There's no good way to test this outside an application, but you can test it locally in Meadow by temporarily changing the dependency spec in `mix.exs` to:

```
{:ueberauth_nusso, git: "https://github.com/nulib/ueberauth_nusso", branch: "2677-handle-invalid-json"} 
```
