### PR TITLE
Disable XSRF state because NUSSO does not support it

### DIFF
--- a/lib/ueberauth/strategy/nusso.ex
+++ b/lib/ueberauth/strategy/nusso.ex
@@ -14,7 +14,7 @@ defmodule Ueberauth.Strategy.NuSSO do
   5. User can proceed to use the Elixir application.
   """
 
-  use Ueberauth.Strategy
+  use Ueberauth.Strategy, ignores_csrf_attack: true
 
   alias Ueberauth.Auth.{Extra, Info}
   alias Ueberauth.Strategy.NuSSO

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UeberauthOpenam.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @url "https://github.com/nulib/ueberauth_nusso"
 
   def project do


### PR DESCRIPTION
You can test this by temporarily updating Meadow's `mix.exs` with:

```
      {:ueberauth, "~> 0.7.0"},
      {:ueberauth_nusso,
       github: "nulib/ueberauth_nusso", branch: "2789-disable-ueberauth-xsrf-protection"},
```

Then `mix deps.get`, `mix phx.server`, and make sure you can log in using a new session.